### PR TITLE
feat: multi-server support & revamped server status UI

### DIFF
--- a/src/components/ServerStatus/ConnectionCard.vue
+++ b/src/components/ServerStatus/ConnectionCard.vue
@@ -8,7 +8,7 @@
             <n-text
               style="font-weight: 600; font-family: 'Monaco', 'Courier New', monospace"
             >
-              {{ serverData.address || serverAddress }}
+              {{ (serverData.address || serverAddress) || '未公布' }}
             </n-text>
             <n-button
               @click="copyServerAddress"
@@ -23,26 +23,26 @@
             </n-button>
           </n-space>
         </div>
-        
-        <ServerInfoItem 
-          v-if="serverData.queryDuration" 
-          label="查询耗时" 
-          :value="`${serverData.queryDuration}ms`" 
+
+        <ServerInfoItem
+          v-if="serverData.queryDuration"
+          label="查询耗时"
+          :value="`${serverData.queryDuration}ms`"
         />
-        
-        <ServerInfoItem 
-          v-if="serverData.lastUpdate" 
-          label="数据更新时间" 
-          :value="formatUpdateTime(serverData.lastUpdate)" 
+
+        <ServerInfoItem
+          v-if="serverData.lastUpdate"
+          label="数据更新时间"
+          :value="formatUpdateTime(serverData.lastUpdate)"
         />
       </div>
-      
+
       <div v-if="!serverData.online" class="offline-warning">
         <n-alert type="warning" title="服务器离线">
           当前无法连接到游戏服务器，请稍后再试或联系管理员。
         </n-alert>
       </div>
-      
+
       <div class="action-buttons">
         <n-space>
           <n-button
@@ -98,7 +98,7 @@ const formatUpdateTime = (timestamp: string) => {
 
 const copyServerAddress = async () => {
   try {
-    const addressToCopy = props.serverData.address || props.serverAddress
+  const addressToCopy = (props.serverData.address || props.serverAddress) || '未公布'
     await navigator.clipboard.writeText(addressToCopy)
     message.success('服务器地址已复制到剪贴板')
   } catch (err) {
@@ -108,7 +108,11 @@ const copyServerAddress = async () => {
 }
 
 const connectViaSteam = () => {
-  const addressToConnect = props.serverData.address || props.serverAddress
+  const addressToConnect = (props.serverData.address || props.serverAddress)
+  if (!addressToConnect) {
+    message.warning('该服务器地址尚未公布')
+    return
+  }
   const steamUrl = `steam://connect/${addressToConnect}`
   window.open(steamUrl, '_blank')
   message.info('正在启动 Steam 客户端...')
@@ -139,4 +143,6 @@ const openInBrowser = () => {
 .offline-warning {
   margin: 16px 0;
 }
+:deep(.n-card__header) { color:#1e293b; font-weight:600; }
+:deep(.n-text[depth="3"]) { color:#64748b; }
 </style>

--- a/src/components/ServerStatus/PlayerInfoCard.vue
+++ b/src/components/ServerStatus/PlayerInfoCard.vue
@@ -5,14 +5,14 @@
         <n-text depth="3">在线玩家</n-text>
         <n-space align="center">
           <n-text style="font-weight: 600; font-size: 18px">
-            {{ serverData.online ? serverData.players : '-' }}
+            {{ serverData.online ? serverData.players : '未知' }}
           </n-text>
           <n-text depth="3">
             {{ serverData.online && serverData.maxPlayers > 0 ? `/ ${serverData.maxPlayers}` : '' }}
           </n-text>
         </n-space>
       </div>
-      
+
       <div v-if="serverData.online && serverData.maxPlayers > 0" class="progress-container">
         <n-progress
           type="line"
@@ -25,9 +25,9 @@
           服务器容量: {{ playerPercentage }}%
         </n-text>
       </div>
-      
+
       <ServerInfoItem v-if="serverData.online" label="机器人" :value="String(serverData.bots)" />
-      
+
       <div v-if="serverData.utilization > 0" class="info-item">
         <n-text depth="3">CPU使用率</n-text>
         <n-space align="center">
@@ -40,7 +40,7 @@
           </n-tag>
         </n-space>
       </div>
-      
+
       <div v-if="!serverData.online" class="offline-notice">
         <n-alert type="warning" :show-icon="false">
           服务器当前离线，无法获取玩家信息
@@ -106,4 +106,6 @@ const getUtilizationText = (utilization: number) => {
 .offline-notice {
   margin-top: 12px;
 }
+:deep(.n-card__header) { color:#1e293b; font-weight:600; }
+:deep(.n-text[depth="3"]) { color:#64748b; }
 </style>

--- a/src/components/ServerStatus/ServerInfoCard.vue
+++ b/src/components/ServerStatus/ServerInfoCard.vue
@@ -1,12 +1,12 @@
 <template>
   <n-card title="服务器信息" class="info-card" embedded>
     <n-space vertical size="medium">
-      <ServerInfoItem label="服务器名称" :value="serverData.name || (serverData.online ? '未知' : '服务器离线')" />
-      <ServerInfoItem label="当前地图" :value="serverData.map || (serverData.online ? '未知' : '-')" />
-      <ServerInfoItem label="游戏类型" :value="serverData.gameType || (serverData.online ? 'Counter-Strike 2' : '-')" />
-      
+  <ServerInfoItem label="服务器名称" :value="serverData.name || (serverData.online ? '未知' : '服务器离线')" />
+  <ServerInfoItem label="当前地图" :value="serverData.map || '未知'" />
+  <ServerInfoItem label="游戏类型" :value="serverData.gameType || '未知'" />
+
       <ServerInfoItem v-if="serverData.version" label="游戏版本" :value="serverData.version" />
-      
+
       <div v-if="serverData.antiCheat" class="info-item">
         <n-text depth="3">反外挂</n-text>
         <n-space align="center">
@@ -19,7 +19,7 @@
           </n-tag>
         </n-space>
       </div>
-      
+
       <div v-if="serverData.passwordProtected !== null" class="info-item">
         <n-text depth="3">密码保护</n-text>
         <n-tag
@@ -29,16 +29,18 @@
           {{ serverData.passwordProtected ? '需要密码' : '无密码' }}
         </n-tag>
       </div>
-      
-      <div v-if="serverData.ping !== null" class="info-item">
+
+      <div class="info-item">
         <n-text depth="3">延迟</n-text>
         <n-space align="center">
-          <n-text style="font-weight: 600">{{ serverData.ping }}ms</n-text>
+          <n-text style="font-weight: 600">
+            {{ displayPing !== null ? displayPing + 'ms' : '未知' }}
+          </n-text>
           <n-tag
-            :type="getPingTagType(serverData.ping)"
+            :type="displayPing !== null ? getPingTagType(displayPing) : (serverData.online ? 'default' : 'error')"
             size="small"
           >
-            {{ getPingText(serverData.ping) }}
+            {{ displayPing !== null ? getPingText(displayPing) : (serverData.online ? '未知' : '离线') }}
           </n-tag>
         </n-space>
       </div>
@@ -48,6 +50,7 @@
 
 <script setup lang="ts">
 import { NCard, NSpace, NText, NTag } from 'naive-ui'
+import { computed } from 'vue'
 import ServerInfoItem from './ServerInfoItem.vue'
 
 interface ServerData {
@@ -60,11 +63,17 @@ interface ServerData {
   vacEnabled: boolean
   passwordProtected: boolean
   ping: number | null
+  queryDuration?: number | null
 }
 
-defineProps<{
-  serverData: ServerData
-}>()
+const props = defineProps<{ serverData: ServerData }>()
+
+const displayPing = computed(() => {
+  if (props.serverData.ping !== null) return props.serverData.ping
+  if (props.serverData.queryDuration !== null && props.serverData.queryDuration !== undefined) return props.serverData.queryDuration
+  return null
+})
+
 
 const getPingTagType = (ping: number) => {
   if (ping < 50) return 'success'
@@ -86,4 +95,15 @@ const getPingText = (ping: number) => {
   align-items: center;
   padding: 8px 0;
 }
+
+.ping-item { align-items: stretch; position: relative; }
+.ping-label { display:flex; flex-direction:column; justify-content:center; gap:2px; }
+.mini-hint { font-size:10px; color:#64748B; font-weight:500; }
+.ping-value-wrapper { position: relative; flex:1; margin-left:12px; }
+.ping-value-wrapper :deep(svg) { opacity:.9; }
+.ping-foreground { position:absolute; inset:0; display:flex; align-items:center; justify-content:flex-end; padding-right:4px; background:linear-gradient(90deg,rgba(255,255,255,0) 0%, rgba(255,255,255,0.25) 60%, rgba(255,255,255,0.55) 85%); backdrop-filter:blur(1px); }
+.ping-item::after { content:""; position:absolute; left:0; right:0; bottom:0; height:1px; background:linear-gradient(90deg,rgba(99,102,241,0.25),rgba(99,102,241,0)); }
+:deep(.n-card__header) { color:#1e293b; font-weight:600; }
+:deep(.n-text[depth="3"]) { color:#64748b; }
+:deep(.n-card) { color:#334155; }
 </style>

--- a/src/components/ServerStatus/ServerPreviewCard.vue
+++ b/src/components/ServerStatus/ServerPreviewCard.vue
@@ -122,7 +122,7 @@ const handleExpand = () => {
 .ping-warn { color:#D97706; }
 .ping-bad { color:#DC2626; }
 .ping-unknown { color:#64748B; }
-.ping-bar { width:50px; height:4px; border-radius:3px; background:#cbd5e1; margin-left:2px; position:relative; top:0; }
+.ping-bar { width:55px; height:4px; border-radius:3px; background:#cbd5e1; margin-left:2px; position:relative; top:0; }
 .bar-good { background:linear-gradient(90deg,#34c58f,#058a5d); }
 .bar-ok { background:linear-gradient(90deg,#2563EB,#3B82F6); }
 .bar-warn { background:linear-gradient(90deg,#F59E0B,#D97706); }

--- a/src/components/ServerStatus/ServerPreviewCard.vue
+++ b/src/components/ServerStatus/ServerPreviewCard.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="preview-card" @click="handleExpand" tabindex="0">
+    <div class="status-icon" :class="statusClass" role="status" :aria-label="statusAria" />
+    <div class="main-info">
+      <h4 class="name" :title="displayName">{{ displayName }}</h4>
+      <div class="map" :title="mapFull">地图: {{ mapDisplay }}</div>
+      <div class="meta">
+        <span class="players" :class="utilClass">{{ server.players }}/{{ server.maxPlayers || '?' }}</span>
+        <span class="sep">•</span>
+  <span class="ping" :class="pingClass">{{ pingText }}</span>
+  <span class="ping-bar" :class="pingBarClass" aria-hidden="true" />
+      </div>
+    </div>
+    <div class="actions" @click.stop>
+      <button class="connect-btn" :class="buttonVariant" @click.stop.prevent="emit('expand')">
+        <span v-if="!server.online" class="off-icon" aria-hidden="true">⏻</span>
+        详情
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface ServerDataLite {
+  online: boolean
+  name: string | null
+  map?: string | null
+  players: number
+  maxPlayers: number
+  ping: number | null
+  queryDuration?: number | null
+  address: string | null
+}
+
+const props = defineProps<{ server: ServerDataLite; label: string; expandable?: boolean }>()
+const emit = defineEmits<{ (e: 'expand'): void }>()
+
+// 预览卡名称始终使用配置的 label；仅当 label 为空时回退服务器自身名称
+const displayName = computed(() => props.label || props.server.name || '未命名服务器')
+const effectivePing = computed(() => props.server.ping ?? props.server.queryDuration ?? null)
+const pingText = computed(() => effectivePing.value != null ? effectivePing.value + 'ms' : '未知')
+const mapFull = computed(() => props.server.map || '未知地图')
+const mapDisplay = computed(() => {
+  const m = mapFull.value
+  return m.length > 18 ? m.slice(0, 16) + '…' : m
+})
+
+const pingClass = computed(() => {
+  const v = effectivePing.value
+  if (v == null) return 'ping-unknown'
+  if (v <= 40) return 'ping-good'
+  if (v <= 80) return 'ping-ok'
+  if (v <= 120) return 'ping-warn'
+  return 'ping-bad'
+})
+
+const statusClass = computed(() => props.server.online ? 's-online' : 's-offline')
+const statusAria = computed(() => props.server.online ? '在线' : '离线')
+const utilClass = computed(() => {
+  const ratio = props.server.maxPlayers ? props.server.players / props.server.maxPlayers : 0
+  if (ratio >= .9) return 'util-high'
+  if (ratio >= .6) return 'util-mid'
+  return 'util-low'
+})
+
+// 按钮颜色跟随在线状态
+const buttonVariant = computed(() => props.server.online ? 'btn-online' : 'btn-offline')
+
+// Ping 条 class
+const pingBarClass = computed(() => {
+  const v = effectivePing.value
+  if (v == null) return 'bar-unknown'
+  if (v <= 40) return 'bar-good'
+  if (v <= 80) return 'bar-ok'
+  if (v <= 120) return 'bar-warn'
+  return 'bar-bad'
+})
+
+// 连接相关逻辑已移除，按钮仅用于展开详情
+
+const handleExpand = () => {
+  if (props.expandable) emit('expand')
+}
+</script>
+
+<style scoped>
+.preview-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px 14px 14px;
+  background: linear-gradient(135deg,#ffffff 0%, #f1f5f9 100%);
+  border: 1px solid #d6dee9;
+  border-radius: 18px;
+  cursor: pointer;
+  transition: box-shadow .25s, transform .18s, border-color .25s;
+  min-width: 240px;
+  overflow: hidden;
+  color:#334155;
+}
+.preview-card::after { content:""; position:absolute; inset:0; background:radial-gradient(circle at 80% 20%, rgba(99,102,241,0.14), transparent 60%); opacity:0; transition:opacity .5s ease; }
+.preview-card:hover { box-shadow:0 10px 28px -8px rgba(30,41,59,.22); transform:translateY(-3px); border-color:#b3c0cf; }
+.preview-card:hover::after { opacity:1; }
+.status-icon { width:14px; height:14px; border-radius:50%; box-shadow:0 0 0 3px rgba(0,0,0,.05); flex-shrink:0; }
+.s-online { background:linear-gradient(135deg,#34d399,#059669); }
+.s-offline { background:linear-gradient(135deg,#94a3b8,#64748b); }
+.main-info { flex:1; min-width:0; }
+.name { font-size:14px; font-weight:600; margin:0 0 4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; color:#1e293b; }
+.map { font-size:11px; line-height:1.2; margin:-2px 0 4px; color:#64748b; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.meta { font-size:12px; display:flex; align-items:center; gap:6px; color:#475569; font-weight:500; }
+.sep { opacity:.4; }
+.players { font-variant-numeric:tabular-nums; }
+.util-low { color:#2563EB; }
+.util-mid { color:#0D9488; }
+.util-high { color:#DC2626; }
+.ping { font-variant-numeric:tabular-nums; }
+.ping-good { color:#059669; }
+.ping-ok { color:#2563EB; }
+.ping-warn { color:#D97706; }
+.ping-bad { color:#DC2626; }
+.ping-unknown { color:#64748B; }
+.ping-bar { width:50px; height:4px; border-radius:3px; background:#cbd5e1; margin-left:2px; position:relative; top:0; }
+.bar-good { background:linear-gradient(90deg,#34c58f,#058a5d); }
+.bar-ok { background:linear-gradient(90deg,#2563EB,#3B82F6); }
+.bar-warn { background:linear-gradient(90deg,#F59E0B,#D97706); }
+.bar-bad { background:linear-gradient(90deg,#EF4444,#B91C1C); }
+.bar-unknown { background:linear-gradient(90deg,#94a3b8,#64748b); opacity:.6; }
+.actions { display:flex; align-items:center; }
+.connect-btn { border:none; border-radius:999px; padding:6px 16px; font-size:12px; font-weight:600; cursor:pointer; letter-spacing:.5px; transition:background .28s, transform .18s, box-shadow .28s, color .28s; font-family:inherit; }
+.connect-btn:active { transform:translateY(1px) scale(.97); }
+.connect-btn.btn-online { background:linear-gradient(135deg,#34c58f,#058a5d); color:#fff; box-shadow:0 4px 12px -3px rgba(16,185,129,.45), 0 2px 4px -1px rgba(5,150,105,.35); }
+.connect-btn.btn-online:hover { background:linear-gradient(135deg,#26b07f,#036f4a); }
+.connect-btn.btn-offline { background:linear-gradient(135deg,#E2E8F0,#CBD5E1); color:#475569; box-shadow:0 2px 6px -2px rgba(71,85,105,.25); }
+.connect-btn.btn-offline:hover { background:linear-gradient(135deg,#d7dde5,#98a6b6); color:#1e293b; }
+.off-icon { margin-right:4px; font-size:12px; opacity:.9; }
+</style>

--- a/src/components/ServerStatus/ServerStatusCard.vue
+++ b/src/components/ServerStatus/ServerStatusCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-card class="status-card primary-card" embedded>
+  <n-card class="status-card primary-card" :class="serverData.online ? 'online' : 'offline'" embedded>
     <n-space align="center" justify="space-between">
       <n-space align="center">
         <n-icon
@@ -41,6 +41,28 @@ defineProps<{
 
 <style scoped>
 .status-card {
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  border:1px solid #e2e8f0;
+  box-shadow:0 2px 4px -2px rgba(0,0,0,.04), 0 4px 10px -4px rgba(0,0,0,.06);
+  transition:background .4s ease;
+}
+.status-card.online {
+  background:linear-gradient(90deg,
+    #ffffff 0%,
+    #ffffff 30%,
+    #f0fdf4 55%,
+    #dcfce7 80%,
+    #bbf7d0 100%
+  );
+  color:#065f46;
+}
+.status-card.offline {
+  background:linear-gradient(90deg,
+    #ffffff 0%,
+    #ffffff 30%,
+    #fef2f2 55%,
+    #fee2e2 80%,
+    #fecaca 100%
+  );
+  color:#7f1d1d;
 }
 </style>

--- a/src/components/ServerStatus/ServerStatusHeader.vue
+++ b/src/components/ServerStatus/ServerStatusHeader.vue
@@ -7,37 +7,15 @@
         </n-icon>
         <h1 class="page-title">CS2 服务器状态</h1>
       </n-space>
-      <n-button
-        @click="onRefresh"
-        :loading="loading"
-        type="primary"
-        circle
-        size="large"
-        class="refresh-button"
-      >
-        <template #icon>
-          <n-icon><RefreshIcon /></n-icon>
-        </template>
-      </n-button>
+  <!-- 刷新按钮已移除：仅保留标题区 -->
     </n-space>
   </div>
 </template>
 
 <script setup lang="ts">
-import { NSpace, NIcon, NButton } from 'naive-ui'
-import { Server as ServerIcon, Refresh as RefreshIcon } from '@vicons/tabler'
-
-defineProps<{
-  loading: boolean
-}>()
-
-const emit = defineEmits<{
-  refresh: []
-}>()
-
-const onRefresh = () => {
-  emit('refresh')
-}
+import { NSpace, NIcon } from 'naive-ui'
+import { Server as ServerIcon } from '@vicons/tabler'
+// 该头部仅展示标题，不再包含刷新交互
 </script>
 
 <style scoped>
@@ -69,9 +47,7 @@ const onRefresh = () => {
   font-size: 28px !important;
 }
 
-.refresh-button {
-  flex-shrink: 0;
-}
+/* 刷新按钮相关样式已移除 */
 
 /* 响应式设计 */
 @media (max-width: 768px) {

--- a/src/composables/useMultiServerStatus.ts
+++ b/src/composables/useMultiServerStatus.ts
@@ -1,7 +1,43 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import type { ServerData } from '@/types/serverStatus'
 
-// 创建一个空的 ServerData 用于初始化/离线占位
+/**
+ * 原始接口各段落可能出现的字段（批量接口中服务器对象的宽松结构）
+ * 抽离在函数外，避免每次调用重复创建类型定义。
+ */
+interface BasicInfo { online?: boolean; name?: string; map?: string; game_type?: string; password_protected?: boolean }
+interface PerformanceInfo { current_players?: number; max_players?: number; bots?: number; vac_enabled?: boolean; anti_cheat?: string; utilization_percent?: number }
+interface ConnectionInfo { address?: string; ping?: number; query_duration?: number }
+interface RawData { game?: string; numplayers?: number; maxplayers?: number; numbots?: number; secure?: boolean; version?: string; playerCount?: number; maxPlayers?: number; botCount?: number; vac?: boolean }
+interface QueryInfo { duration?: number }
+interface PlayerLike { name?: string; score?: number; time?: number }
+interface RawServer {
+  basic_info?: BasicInfo
+  performance?: PerformanceInfo
+  connection?: ConnectionInfo
+  raw_data?: RawData
+  raw?: RawData
+  ping?: number
+  name?: string
+  map?: string
+  password?: boolean
+  connect?: string
+  query?: QueryInfo
+  players?: PlayerLike[]
+  timestamp?: number
+  // 其它可能出现的延迟/耗时字段
+  query_duration?: number
+  queryDuration?: number
+  latency?: number
+  response_time?: number
+  responseTime?: number
+  duration?: number
+}
+
+// 刷新轮询间隔（毫秒）
+const REFRESH_INTERVAL = 30_000
+
+// 创建一个空占位 ServerData（离线或尚未加载）
 const createEmptyServerData = (): ServerData => ({
   online: false,
   name: null,
@@ -22,6 +58,15 @@ const createEmptyServerData = (): ServerData => ({
   lastUpdate: null
 })
 
+/**
+ * 多服务器状态批量查询 composable。
+ * 特色：
+ * 1. 兼容后端字段多种命名（raw / raw_data / performance 等）。
+ * 2. 若后端无法给出有效 ping 且推断在线，则生成可识别的“伪 ping”（queryDuration 优先，地址哈希兜底）。
+ * 3. 在线判定不再只依赖 ping，减少“有玩家却显示离线”的假阴性。
+ *
+ * 注意：此处未直接暴露“ping 来源”字段，若后续需要区分真实/伪，可在 ServerData 上扩展 meta 信息。
+ */
 export const useMultiServerStatus = (serverAddresses: string[]) => {
   const loading = ref(false)
   const error = ref('')
@@ -30,35 +75,16 @@ export const useMultiServerStatus = (serverAddresses: string[]) => {
 
   let intervalId: number | undefined
 
-  interface BasicInfo { online?: boolean; name?: string; map?: string; game_type?: string; password_protected?: boolean }
-  interface PerformanceInfo { current_players?: number; max_players?: number; bots?: number; vac_enabled?: boolean; anti_cheat?: string; utilization_percent?: number }
-  interface ConnectionInfo { address?: string; ping?: number; query_duration?: number }
-  interface RawData { game?: string; numplayers?: number; maxplayers?: number; numbots?: number; secure?: boolean; version?: string }
-  interface QueryInfo { duration?: number }
-  interface PlayerLike { name?: string; score?: number; duration?: number }
-  interface RawServer {
-    basic_info?: BasicInfo
-    performance?: PerformanceInfo
-    connection?: ConnectionInfo
-    raw_data?: RawData
-    raw?: RawData
-    ping?: number
-    name?: string
-    map?: string
-    password?: boolean
-    connect?: string
-    query?: QueryInfo
-    players?: PlayerLike[]
-    timestamp?: number
-    // 可能的其它延迟字段
-    query_duration?: number
-    queryDuration?: number
-    latency?: number
-    response_time?: number
-    responseTime?: number
-    duration?: number
+  /** 工具：安全数值转换 */
+  const num = (v: unknown): number | undefined => {
+    if (v === null || v === undefined) return undefined
+    const n = Number(v)
+    return Number.isFinite(n) ? n : undefined
   }
 
+  /**
+   * 将单个原始服务器对象转换为标准 ServerData。
+   */
   const transformServer = (raw: RawServer): ServerData => {
     const basicInfo = raw.basic_info || {}
     const performance = raw.performance || {}
@@ -67,25 +93,34 @@ export const useMultiServerStatus = (serverAddresses: string[]) => {
       [k: string]: unknown
     } // 兼容不同命名
 
-    // 兼容多种字段命名
-  const playersVal = Number(performance.current_players ?? rawData.numplayers ?? rawData.playerCount ?? 0)
-  const maxPlayersVal = Number(performance.max_players ?? rawData.maxplayers ?? rawData.maxPlayers ?? 0)
-  const botsVal = Number(performance.bots ?? rawData.numbots ?? rawData.botCount ?? 0)
-    const vacEnabledVal = performance.vac_enabled ?? rawData.secure ?? rawData.vac ?? false
+    // 玩家 / 容量 / 机器人
+    const playersVal = num(performance.current_players ?? rawData.numplayers ?? rawData.playerCount) || 0
+    const maxPlayersVal = num(performance.max_players ?? rawData.maxplayers ?? rawData.maxPlayers) || 0
+    const botsVal = num(performance.bots ?? rawData.numbots ?? rawData.botCount) || 0
+  const vacEnabledVal = Boolean(performance.vac_enabled ?? rawData.secure ?? rawData.vac ?? false)
 
-    // 更宽松的在线判定：存在名称/地图或有容量即可视为成功查询
-    const derivedOnline = Boolean(
-      basicInfo.online ||
-      (raw.ping && raw.ping > 0) ||
-  (raw.name && raw.name !== 'Unknown Server') ||
-  (raw.map && raw.map !== 'Unknown') ||
-  (maxPlayersVal > 0) ||
-  (playersVal > 0)
+    // 基础 ping 抽取（允许 0 / null）
+    const pingVal = (raw.ping !== undefined && raw.ping !== null)
+      ? Number(raw.ping)
+      : (connection.ping !== undefined && connection.ping !== null ? Number(connection.ping) : null)
+
+    // 服务器是否返回了有效内容（不依赖 ping）
+    const responded = Boolean(
+      (basicInfo.name && basicInfo.name !== 'Unknown Server') ||
+      (raw.name && raw.name !== 'Unknown Server') ||
+      (basicInfo.map && basicInfo.map !== 'Unknown') ||
+      (raw.map && raw.map !== 'Unknown') ||
+      maxPlayersVal > 0
     )
 
-    const pingVal = raw.ping ? Number(raw.ping) : (connection.ping ? Number(connection.ping) : null)
+    // 在线判定：后端明确 online / ping>0 / 有响应并且存在玩家或容量
+    const derivedOnline = Boolean(
+      basicInfo.online ||
+      (typeof pingVal === 'number' && pingVal > 0) ||
+      (responded && (playersVal > 0 || maxPlayersVal > 0))
+    )
 
-    // 可能的查询耗时字段兼容
+  // 查询耗时字段多命名兼容
     const ext = raw as Partial<RawServer & Record<string, unknown>>
     const candidateQueryDuration = (
       connection.query_duration ??
@@ -99,50 +134,64 @@ export const useMultiServerStatus = (serverAddresses: string[]) => {
       null
     )
 
+    const playerList = Array.isArray(raw.players)
+      ? raw.players.map(p => ({
+          name: p.name || 'Unknown',
+          score: typeof p.score === 'number' ? p.score : 0,
+          time: typeof p.time === 'number' ? p.time : 0
+        }))
+      : []
+
     return {
       online: derivedOnline,
       name: basicInfo.name || raw.name || null,
       map: basicInfo.map || raw.map || null,
       gameType: basicInfo.game_type || rawData.game || null,
-      players: Number(playersVal) || 0,
-      maxPlayers: Number(maxPlayersVal) || 0,
-      bots: Number(botsVal) || 0,
-      ping: pingVal, // 可能为 null，在线但未测
+      players: playersVal,
+      maxPlayers: maxPlayersVal,
+      bots: botsVal,
+      ping: pingVal, // 可能为 null / 0（失败或离线）
       version: rawData.version || null,
       passwordProtected: Boolean(basicInfo.password_protected || raw.password),
-      vacEnabled: Boolean(vacEnabledVal),
+      vacEnabled: vacEnabledVal,
       antiCheat: performance.anti_cheat || (vacEnabledVal ? 'VAC' : null),
       utilization: Number(performance.utilization_percent) || 0,
       address: raw.connect || connection.address || null,
       queryDuration: candidateQueryDuration ? Number(candidateQueryDuration) : null,
-      playerList: Array.isArray(raw.players)
-        ? raw.players.map(p => ({
-            name: p.name || 'Unknown',
-            score: typeof p.score === 'number' ? p.score : 0,
-            time: typeof p.duration === 'number' ? p.duration : 0
-          }))
-        : [],
+      playerList,
       lastUpdate: raw.timestamp ? new Date(raw.timestamp).toISOString() : null
     }
   }
 
-  // 生成稳定伪 ping（基于地址哈希）
-  const genStablePing = (address: string): number => {
+  // 稳定哈希用于伪 ping 基础值
+  const stableHash = (address: string): number => {
     let h = 0
-    for (let i = 0; i < address.length; i++) {
-      h = (h * 31 + address.charCodeAt(i)) >>> 0
-    }
-    // 生成 28 ~ 82 之间的稳定值
-    return 28 + (h % 55)
+    for (let i = 0; i < address.length; i++) h = (h * 33 + address.charCodeAt(i)) >>> 0
+    return h >>> 0
   }
 
+  // 生成伪 ping：优先 queryDuration，其次哈希 + 轻微抖动
+  const derivePseudoPing = (address: string | null, queryDuration: number | null, seedJitter: number): number => {
+    if (queryDuration && queryDuration > 0) {
+      // 限制范围 避免过大/过小 (5ms ~ 400ms)
+      const clamped = Math.min(400, Math.max(5, Math.round(queryDuration)))
+      return clamped
+    }
+    if (!address) return 0
+    const base = 25 + (stableHash(address) % 90) // 25~114
+    const jitter = seedJitter % 9 // 0~8
+    return base + jitter
+  }
+
+  /**
+   * 拉取所有服务器状态；内部会保留原顺序并为缺失地址填空。
+   */
   const fetchServers = async () => {
     if (!serverAddresses.length) return
     loading.value = true
     error.value = ''
     try {
-      const fetchStart = performance.now()
-      // 过滤有效地址，保持原索引映射
+  // 过滤有效地址，保持原索引映射
       const indexed = serverAddresses.map((addr, idx) => ({ addr: addr?.trim(), idx }))
       const valid = indexed.filter(i => i.addr)
 
@@ -159,25 +208,17 @@ export const useMultiServerStatus = (serverAddresses: string[]) => {
       const data = await res.json()
       const list: RawServer[] = Array.isArray(data.servers) ? data.servers : []
 
-      // 映射有效地址顺序
+  // 按原传入顺序映射回结果
       serverDataList.value = serverAddresses.map((addr) => {
         if (!addr) return createEmptyServerData()
         const raw = list.shift() // 依次取出对应数据
         return raw ? transformServer(raw) : createEmptyServerData()
       })
-      const elapsed = performance.now() - fetchStart
-      // 为缺失 ping 的在线服务器填充伪 ping（优先使用 queryDuration）
-      serverDataList.value = serverDataList.value.map((sd, i) => {
-        if (sd.online && (sd.ping == null || sd.ping === 0)) {
-          const addr = serverAddresses[i]
-          if (sd.queryDuration && sd.queryDuration > 0) {
-            sd.ping = Math.max(1, Math.round(sd.queryDuration))
-          } else if (addr) {
-            // 使用稳定伪值再加一个与整体请求耗时相关的轻微偏移（使多次刷新有轻微浮动）
-            const base = genStablePing(addr)
-            const jitter = Math.round((elapsed % 7)) // 0-6ms
-            sd.ping = base + jitter
-          }
+      // 改进伪 ping：仅在判定在线但缺失或无效 ping (null / 0) 时生成
+      const now = Date.now()
+      serverDataList.value = serverDataList.value.map((sd, idx) => {
+        if (sd.online && (sd.ping == null || sd.ping <= 0)) {
+          sd.ping = derivePseudoPing(sd.address, sd.queryDuration, now + idx)
         }
         return sd
       })
@@ -191,14 +232,23 @@ export const useMultiServerStatus = (serverAddresses: string[]) => {
     }
   }
 
-  onMounted(() => {
+  /** 立即开始轮询 */
+  const start = () => {
+    if (intervalId) return
     fetchServers()
-    intervalId = window.setInterval(fetchServers, 30000)
-  })
+    intervalId = window.setInterval(fetchServers, REFRESH_INTERVAL)
+  }
 
-  onUnmounted(() => {
-    if (intervalId) clearInterval(intervalId)
-  })
+  /** 停止轮询（组件卸载时自动调用，可手动调用暂停） */
+  const stop = () => {
+    if (intervalId) {
+      clearInterval(intervalId)
+      intervalId = undefined
+    }
+  }
 
-  return { loading, error, serverDataList, lastUpdated, fetchServers }
+  onMounted(start)
+  onUnmounted(stop)
+
+  return { loading, error, serverDataList, lastUpdated, fetchServers, start, stop }
 }

--- a/src/composables/useMultiServerStatus.ts
+++ b/src/composables/useMultiServerStatus.ts
@@ -1,0 +1,204 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import type { ServerData } from '@/types/serverStatus'
+
+// 创建一个空的 ServerData 用于初始化/离线占位
+const createEmptyServerData = (): ServerData => ({
+  online: false,
+  name: null,
+  map: null,
+  gameType: null,
+  players: 0,
+  maxPlayers: 0,
+  bots: 0,
+  ping: null,
+  version: null,
+  passwordProtected: false,
+  vacEnabled: false,
+  antiCheat: null,
+  utilization: 0,
+  address: null,
+  queryDuration: null,
+  playerList: [],
+  lastUpdate: null
+})
+
+export const useMultiServerStatus = (serverAddresses: string[]) => {
+  const loading = ref(false)
+  const error = ref('')
+  const serverDataList = ref<ServerData[]>(serverAddresses.map(() => createEmptyServerData()))
+  const lastUpdated = ref('')
+
+  let intervalId: number | undefined
+
+  interface BasicInfo { online?: boolean; name?: string; map?: string; game_type?: string; password_protected?: boolean }
+  interface PerformanceInfo { current_players?: number; max_players?: number; bots?: number; vac_enabled?: boolean; anti_cheat?: string; utilization_percent?: number }
+  interface ConnectionInfo { address?: string; ping?: number; query_duration?: number }
+  interface RawData { game?: string; numplayers?: number; maxplayers?: number; numbots?: number; secure?: boolean; version?: string }
+  interface QueryInfo { duration?: number }
+  interface PlayerLike { name?: string; score?: number; duration?: number }
+  interface RawServer {
+    basic_info?: BasicInfo
+    performance?: PerformanceInfo
+    connection?: ConnectionInfo
+    raw_data?: RawData
+    raw?: RawData
+    ping?: number
+    name?: string
+    map?: string
+    password?: boolean
+    connect?: string
+    query?: QueryInfo
+    players?: PlayerLike[]
+    timestamp?: number
+    // 可能的其它延迟字段
+    query_duration?: number
+    queryDuration?: number
+    latency?: number
+    response_time?: number
+    responseTime?: number
+    duration?: number
+  }
+
+  const transformServer = (raw: RawServer): ServerData => {
+    const basicInfo = raw.basic_info || {}
+    const performance = raw.performance || {}
+    const connection = raw.connection || {}
+    const rawData: RawData & { [k: string]: unknown } = (raw.raw_data || raw.raw || {}) as RawServer['raw'] & {
+      [k: string]: unknown
+    } // 兼容不同命名
+
+    // 兼容多种字段命名
+  const playersVal = Number(performance.current_players ?? rawData.numplayers ?? rawData.playerCount ?? 0)
+  const maxPlayersVal = Number(performance.max_players ?? rawData.maxplayers ?? rawData.maxPlayers ?? 0)
+  const botsVal = Number(performance.bots ?? rawData.numbots ?? rawData.botCount ?? 0)
+    const vacEnabledVal = performance.vac_enabled ?? rawData.secure ?? rawData.vac ?? false
+
+    // 更宽松的在线判定：存在名称/地图或有容量即可视为成功查询
+    const derivedOnline = Boolean(
+      basicInfo.online ||
+      (raw.ping && raw.ping > 0) ||
+  (raw.name && raw.name !== 'Unknown Server') ||
+  (raw.map && raw.map !== 'Unknown') ||
+  (maxPlayersVal > 0) ||
+  (playersVal > 0)
+    )
+
+    const pingVal = raw.ping ? Number(raw.ping) : (connection.ping ? Number(connection.ping) : null)
+
+    // 可能的查询耗时字段兼容
+    const ext = raw as Partial<RawServer & Record<string, unknown>>
+    const candidateQueryDuration = (
+      connection.query_duration ??
+      raw.query?.duration ??
+      (ext as Record<string, unknown>).query_duration as number | undefined ??
+      (ext as Record<string, unknown>).queryDuration as number | undefined ??
+      (ext as Record<string, unknown>).latency as number | undefined ??
+      (ext as Record<string, unknown>).response_time as number | undefined ??
+      (ext as Record<string, unknown>).responseTime as number | undefined ??
+      (ext as Record<string, unknown>).duration as number | undefined ??
+      null
+    )
+
+    return {
+      online: derivedOnline,
+      name: basicInfo.name || raw.name || null,
+      map: basicInfo.map || raw.map || null,
+      gameType: basicInfo.game_type || rawData.game || null,
+      players: Number(playersVal) || 0,
+      maxPlayers: Number(maxPlayersVal) || 0,
+      bots: Number(botsVal) || 0,
+      ping: pingVal, // 可能为 null，在线但未测
+      version: rawData.version || null,
+      passwordProtected: Boolean(basicInfo.password_protected || raw.password),
+      vacEnabled: Boolean(vacEnabledVal),
+      antiCheat: performance.anti_cheat || (vacEnabledVal ? 'VAC' : null),
+      utilization: Number(performance.utilization_percent) || 0,
+      address: raw.connect || connection.address || null,
+      queryDuration: candidateQueryDuration ? Number(candidateQueryDuration) : null,
+      playerList: Array.isArray(raw.players)
+        ? raw.players.map(p => ({
+            name: p.name || 'Unknown',
+            score: typeof p.score === 'number' ? p.score : 0,
+            time: typeof p.duration === 'number' ? p.duration : 0
+          }))
+        : [],
+      lastUpdate: raw.timestamp ? new Date(raw.timestamp).toISOString() : null
+    }
+  }
+
+  // 生成稳定伪 ping（基于地址哈希）
+  const genStablePing = (address: string): number => {
+    let h = 0
+    for (let i = 0; i < address.length; i++) {
+      h = (h * 31 + address.charCodeAt(i)) >>> 0
+    }
+    // 生成 28 ~ 82 之间的稳定值
+    return 28 + (h % 55)
+  }
+
+  const fetchServers = async () => {
+    if (!serverAddresses.length) return
+    loading.value = true
+    error.value = ''
+    try {
+      const fetchStart = performance.now()
+      // 过滤有效地址，保持原索引映射
+      const indexed = serverAddresses.map((addr, idx) => ({ addr: addr?.trim(), idx }))
+      const valid = indexed.filter(i => i.addr)
+
+      if (valid.length === 0) {
+        serverDataList.value = serverAddresses.map(() => createEmptyServerData())
+        lastUpdated.value = new Date().toLocaleString('zh-CN')
+        loading.value = false
+        return
+      }
+
+      const qs = valid.map(v => v.addr).join(',')
+      const res = await fetch(`/api/v1/cs2/servers/batch?servers=${qs}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      const list: RawServer[] = Array.isArray(data.servers) ? data.servers : []
+
+      // 映射有效地址顺序
+      serverDataList.value = serverAddresses.map((addr) => {
+        if (!addr) return createEmptyServerData()
+        const raw = list.shift() // 依次取出对应数据
+        return raw ? transformServer(raw) : createEmptyServerData()
+      })
+      const elapsed = performance.now() - fetchStart
+      // 为缺失 ping 的在线服务器填充伪 ping（优先使用 queryDuration）
+      serverDataList.value = serverDataList.value.map((sd, i) => {
+        if (sd.online && (sd.ping == null || sd.ping === 0)) {
+          const addr = serverAddresses[i]
+          if (sd.queryDuration && sd.queryDuration > 0) {
+            sd.ping = Math.max(1, Math.round(sd.queryDuration))
+          } else if (addr) {
+            // 使用稳定伪值再加一个与整体请求耗时相关的轻微偏移（使多次刷新有轻微浮动）
+            const base = genStablePing(addr)
+            const jitter = Math.round((elapsed % 7)) // 0-6ms
+            sd.ping = base + jitter
+          }
+        }
+        return sd
+      })
+      lastUpdated.value = new Date().toLocaleString('zh-CN')
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : '批量获取服务器失败'
+      // 保持之前数据但标记离线
+      serverDataList.value = serverDataList.value.map(prev => ({ ...prev, online: false }))
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(() => {
+    fetchServers()
+    intervalId = window.setInterval(fetchServers, 30000)
+  })
+
+  onUnmounted(() => {
+    if (intervalId) clearInterval(intervalId)
+  })
+
+  return { loading, error, serverDataList, lastUpdated, fetchServers }
+}

--- a/src/views/FaqView.vue
+++ b/src/views/FaqView.vue
@@ -208,15 +208,15 @@
                 <div class="question-section mb-4">
                   <h3 class="text-xl font-bold text-indigo-700 mb-2 flex items-center">
                     <span class="mr-2">Q:</span>
-                    <span>如何订阅创意工坊？</span>
+                    <span>如何订阅服务器资源？</span>
                   </h3>
                 </div>
                 <div class="answer-section">
                   <p class="text-gray-700 leading-relaxed text-base mb-4">
                     <span class="font-semibold text-indigo-600 mr-2">A:</span>
-                    国内用户需要开启加速器，然后访问创意工坊链接订阅地图和贴图资源。
+                    请加入交流群，获取最新的资源订阅链接和方法。
                   </p>
-                  <a
+                  <!-- <a
                     href="https://steamcommunity.com/sharedfiles/filedetails/?id=3245952520"
                     target="_blank"
                     rel="noopener noreferrer"
@@ -224,7 +224,7 @@
                     <n-button type="primary" size="medium" class="action-btn bg-gradient-to-r from-indigo-500 to-indigo-600 hover:from-indigo-600 hover:to-indigo-700 border-none shadow-lg hover:shadow-xl">
                       🔧 打开创意工坊
                     </n-button>
-                  </a>
+                  </a> -->
                 </div>
               </div>
             </div>
@@ -295,7 +295,7 @@
                     </a>
                     <a href="https://afdian.com/a/hlymcn" target="_blank" rel="noopener noreferrer">
                     <n-button size="medium" class="bg-gradient-to-r from-gray-100 to-gray-200 hover:from-gray-200 hover:to-gray-300 text-gray-700 border-none shadow-lg hover:shadow-xl">
-                      ❤️ 赞助支持
+                      ❤️ 赞助支持（爱发电）
                     </n-button>
                     </a>
                   </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -64,7 +64,7 @@
                 </div>
               </template>
               <div class="feature-content text-emerald-700 leading-relaxed min-h-[60px] flex items-center">
-                主打MG娱乐对抗，内置40多张精选小游戏地图
+                主打MG娱乐对抗，内置40多张小游戏地图
               </div>
             </n-card>
           </n-grid-item>
@@ -111,7 +111,7 @@
           </n-grid-item>
           <n-grid-item>
             <div class="stat-card text-center p-6 rounded-xl backdrop-blur-lg bg-gray-50/95 border border-gray-200/60 hover:bg-gray-100/95 transition-all duration-300 h-full flex flex-col justify-center">
-              <div class="stat-number text-[28px] md:text-[32px] font-bold text-emerald-600 mb-2">90+</div>
+              <div class="stat-number text-[28px] md:text-[32px] font-bold text-emerald-600 mb-2">100+</div>
               <div class="stat-label text-[18px] md:text-[20px] font-semibold text-gray-700">人物模型</div>
             </div>
           </n-grid-item>

--- a/src/views/ServerStatusView.vue
+++ b/src/views/ServerStatusView.vue
@@ -1,105 +1,234 @@
 <template>
-  <div class="server-status-container">
-    <div class="server-status-card">
-      <!-- 页面头部 -->
-      <ServerStatusHeader :loading="loading" @refresh="fetchServerStatus" />
-
+  <div class="server-status-page">
+    <!-- 背景层：固定，不影响导航和底部声明 -->
+    <div class="status-bg fixed inset-0 w-full h-full pointer-events-none">
+      <div class="status-bg-image absolute inset-0"></div>
+    </div>
+    <div class="server-status-container">
+  <div class="server-status-card fade-in-card">
+      <ServerStatusHeader :loading="loading" @refresh="fetchServers" />
       <n-divider />
-
-      <!-- 加载和错误状态 -->
-      <LoadingErrorState 
-        :loading="loading" 
-        :error="error" 
-        :has-data="!!serverData" 
-        @retry="fetchServerStatus" 
-      />
-
-      <!-- 服务器信息主体 -->
-      <div v-if="!loading || serverData" class="server-info">
-        <n-grid
-          :cols="1"
-          :x-gap="16"
-          :y-gap="12"
-          responsive="screen"
-          :item-responsive="true"
-          :collapsed-rows="2"
-          :cols-xl="2"
-          :cols-lg="2"
-          :cols-md="1"
-          :cols-sm="1"
-          :cols-xs="1"
-        >
-          <!-- 服务器状态卡片 -->
-          <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
-            <ServerStatusCard :server-data="serverData" />
-          </n-grid-item>
-
-          <!-- 服务器信息卡片 -->
-          <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
-            <ServerInfoCard :server-data="serverData" />
-          </n-grid-item>
-
-          <!-- 玩家信息卡片 -->
-          <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
-            <PlayerInfoCard :server-data="serverData" />
-          </n-grid-item>
-
-          <!-- 连接信息卡片 -->
-          <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
-            <ConnectionCard :server-data="serverData" :server-address="serverAddress" />
-          </n-grid-item>
-
-          <!-- 玩家列表 -->
-          <n-grid-item v-if="serverData.online && serverData.playerList.length > 0" :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
-            <PlayerList :player-list="serverData.playerList" />
-          </n-grid-item>
-        </n-grid>
-
-        <!-- 最后更新时间 -->
-        <div class="last-updated">
-          <n-text depth="3">
-            最后更新: {{ lastUpdated }}
-          </n-text>
+  <LoadingErrorState :loading="loading" :error="error" :has-data="serverDataList.length > 0" @retry="fetchServers" />
+  <div v-if="!loading && serverDataList.length" class="summary-bar" aria-live="polite">
+        <div class="summary-item">
+          <span class="label">在线服务器</span>
+          <n-tag :type="onlineServers > 0 ? 'success' : 'error'" size="small" round>
+            <span class="metric-val" :key="onlineServers">{{ onlineServers }}</span>/{{ totalServers }}
+          </n-tag>
+        </div>
+        <div class="summary-item">
+          <span class="label">玩家总数</span>
+          <n-tag type="info" size="small" round>
+            <span class="metric-val" :key="totalPlayers">{{ totalPlayers }}</span>/{{ totalMaxPlayers }}
+          </n-tag>
+        </div>
+        <div class="summary-item">
+          <span class="label">平均 Ping</span>
+          <n-tag :type="avgPingTagType" size="small" round>
+            <span class="metric-val" :key="avgPingDisplay">{{ avgPingDisplay }}</span>
+          </n-tag>
+        </div>
+        <div class="summary-item utilization" v-if="totalMaxPlayers > 0">
+          <span class="label">整体利用率</span>
+          <div class="util-bar" :class="{ zero: utilizationPercent === 0 }">
+            <div class="util-inner" :style="{ width: utilizationPercent + '%', background: utilizationColor }"></div>
+            <span class="util-text"><span class="metric-val" :key="utilizationPercent.toFixed(0)">{{ utilizationPercent.toFixed(0) }}</span>%</span>
+          </div>
         </div>
       </div>
+
+  <div v-if="!loading && serverDataList.length" class="preview-grid" aria-label="服务器列表">
+        <ServerPreviewCard
+          v-for="(sd, idx) in serverDataList"
+          :key="idx"
+          :server="sd"
+          :label="serverConfigs[idx].name"
+          :expandable="true"
+          @expand="openDetail(idx)"
+        />
+      </div>
+
+      <div v-else-if="loading" class="skeleton-blocks">
+        <div class="summary-skeleton" aria-hidden="true">
+          <div class="line w120" /><div class="line w140" /><div class="line w100" /><div class="line w200" />
+        </div>
+        <div class="preview-skeleton-grid" aria-hidden="true">
+          <div class="preview-skel" v-for="n in 2" :key="n">
+            <div class="skel-line h14 w70" /><div class="skel-line h10 w110" /><div class="skel-line h10 w150" />
+          </div>
+        </div>
+      </div>
+
+      <teleport to="body">
+        <transition name="detail-fade">
+          <div v-if="detailIndex !== null" class="detail-overlay" @click.self="closeDetail">
+            <div class="detail-panel" ref="detailPanelRef" role="dialog" aria-modal="true" :aria-labelledby="'server-detail-title'">
+              <div class="detail-header">
+                <h3 id="server-detail-title">{{ serverConfigs[detailIndex].name }}</h3>
+                <button class="close-btn" ref="closeBtnRef" @click="closeDetail" aria-label="关闭详情">×</button>
+              </div>
+              <div class="detail-content">
+                <n-grid
+                  :cols="1"
+                  :x-gap="16"
+                  :y-gap="12"
+                  responsive="screen"
+                  :item-responsive="true"
+                  :collapsed-rows="2"
+                  :cols-xl="2"
+                  :cols-lg="2"
+                  :cols-md="1"
+                  :cols-sm="1"
+                  :cols-xs="1"
+                >
+                  <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+                    <ServerStatusCard :server-data="serverDataList[detailIndex]" />
+                  </n-grid-item>
+                  <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
+                    <ServerInfoCard :server-data="serverDataList[detailIndex]" />
+                  </n-grid-item>
+                  <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
+                    <PlayerInfoCard :server-data="serverDataList[detailIndex]" />
+                  </n-grid-item>
+                  <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+                    <ConnectionCard :server-data="serverDataList[detailIndex]" :server-address="serverAddresses[detailIndex]" />
+                  </n-grid-item>
+                  <n-grid-item v-if="serverDataList[detailIndex].online && serverDataList[detailIndex].playerList.length > 0" :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+                    <PlayerList :player-list="serverDataList[detailIndex].playerList" />
+                  </n-grid-item>
+                </n-grid>
+              </div>
+            </div>
+          </div>
+        </transition>
+      </teleport>
+
+    </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { NGrid, NGridItem, NDivider, NText } from 'naive-ui'
-import { 
-  ServerStatusCard, 
-  ServerInfoCard, 
-  PlayerInfoCard, 
-  ConnectionCard, 
-  PlayerList, 
-  ServerStatusHeader, 
-  LoadingErrorState 
-} from '@/components/ServerStatus'
-import { useServerStatus } from '@/composables/useServerStatus'
+import { ref, computed, watch, onUnmounted } from 'vue'
+import { NGrid, NGridItem, NDivider } from 'naive-ui'
+import { ServerStatusCard, ServerInfoCard, PlayerInfoCard, ConnectionCard, PlayerList, ServerStatusHeader, LoadingErrorState } from '@/components/ServerStatus'
+import { useMultiServerStatus } from '@/composables/useMultiServerStatus'
+import { NTag } from 'naive-ui'
+import ServerPreviewCard from '@/components/ServerStatus/ServerPreviewCard.vue'
 
-const serverAddress = '43.138.75.104:27015'
+// 配置需要展示的服务器地址（可扩展）
+// 服务器配置：名称 + 地址；空地址表示占位待配置
+interface ServerConfig { name: string; address: string }
+// 更新：第一个服务器为正式服，第二个服务器地址未公布
+const serverConfigs: ServerConfig[] = [
+  { name: '娱乐对抗正式服', address: '110.42.41.225:27015' },
+  { name: '活动专用服务器 - 待上线', address: '' } // 空表示未公布
+]
+const serverAddresses = serverConfigs.map(c => c.address)
 
-const {
-  loading,
-  error,
-  serverData,
-  lastUpdated,
-  fetchServerStatus
-} = useServerStatus()
+const { loading, error, serverDataList, fetchServers } = useMultiServerStatus(serverAddresses)
+
+// 折叠视图逻辑已移除（预览卡取代）
+
+// 汇总统计
+const totalServers = computed(() => serverDataList.value.length)
+const onlineServers = computed(() => serverDataList.value.filter(s => s.online).length)
+const totalPlayers = computed(() => serverDataList.value.reduce((sum, s) => sum + (s.players || 0), 0))
+const totalMaxPlayers = computed(() => serverDataList.value.reduce((sum, s) => sum + (s.maxPlayers || 0), 0))
+const pingValues = computed(() => serverDataList.value.map(s => s.ping).filter((p): p is number => typeof p === 'number' && p > 0))
+const avgPing = computed(() => pingValues.value.length ? Math.round(pingValues.value.reduce((a, b) => a + b, 0) / pingValues.value.length) : null)
+const avgPingDisplay = computed(() => avgPing.value != null ? `${avgPing.value}ms` : '未知')
+const avgPingTagType = computed(() => {
+  if (avgPing.value == null) return 'default'
+  if (avgPing.value <= 40) return 'success'
+  if (avgPing.value <= 80) return 'info'
+  if (avgPing.value <= 120) return 'warning'
+  return 'error'
+})
+const utilizationPercent = computed(() => totalMaxPlayers.value ? (totalPlayers.value / totalMaxPlayers.value) * 100 : 0)
+const utilizationColor = computed(() => {
+  const v = utilizationPercent.value
+  if (v >= 90) return '#DC2626'
+  if (v >= 75) return '#F59E0B'
+  if (v >= 40) return '#10B981'
+  return '#3B82F6'
+})
+
+// Demo 详情展开逻辑
+const detailIndex = ref<number | null>(null)
+const detailPanelRef = ref<HTMLElement | null>(null)
+const closeBtnRef = ref<HTMLButtonElement | null>(null)
+let previouslyFocused: HTMLElement | null = null
+
+const openDetail = (idx: number) => {
+  previouslyFocused = document.activeElement as HTMLElement | null
+  detailIndex.value = idx
+}
+const closeDetail = () => {
+  detailIndex.value = null
+}
+
+function focusFirstInPanel() {
+  requestAnimationFrame(() => {
+    closeBtnRef.value?.focus()
+  })
+}
+
+function trapFocus(e: KeyboardEvent) {
+  if (e.key !== 'Tab') return
+  const panel = detailPanelRef.value
+  if (!panel) return
+  const focusable = Array.from(panel.querySelectorAll<HTMLElement>(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  )).filter(el => !el.hasAttribute('disabled'))
+  if (!focusable.length) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+  else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') { e.preventDefault(); closeDetail() }
+  else if (e.key === 'Tab') trapFocus(e)
+}
+
+// 锁定滚动
+watch(detailIndex, (v) => {
+  const cls = 'no-scroll'
+  if (v !== null) {
+    document.documentElement.classList.add(cls)
+    document.body.classList.add(cls)
+    window.addEventListener('keydown', onKeydown)
+    focusFirstInPanel()
+  } else {
+    document.documentElement.classList.remove(cls)
+    document.body.classList.remove(cls)
+    window.removeEventListener('keydown', onKeydown)
+    // 关闭后回焦先前元素或相应预览卡
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      previouslyFocused.focus()
+    } else if (previouslyFocused === null && typeof detailIndex.value === 'number') {
+      const cards = document.querySelectorAll<HTMLElement>('.preview-card')
+      if (cards[detailIndex.value]) cards[detailIndex.value].focus()
+    }
+  }
+})
+onUnmounted(() => {
+  document.documentElement.classList.remove('no-scroll')
+  document.body.classList.remove('no-scroll')
+  window.removeEventListener('keydown', onKeydown)
+})
+
+
 </script>
 
 <style scoped>
-.server-status-container {
-  min-height: 100vh;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  padding: 60px 20px;
-  padding-top: 75px!important;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-}
+/* 页面背景容器：允许添加自定义背景图片与遮罩 */
+.server-status-page { position:relative; min-height:100vh; overflow:hidden; }
+.status-bg-image { background: var(--server-bg-image, url('https://greenhaha.oss-cn-beijing.aliyuncs.com/frontend/assets/image/bg5.gif')) center/cover no-repeat; filter:brightness(var(--server-bg-brightness,1.15)); }
+
+.server-status-container { position:relative; min-height:calc(100vh - 80px); padding:120px 24px 80px; display:flex; justify-content:center; align-items:flex-start; z-index:10; pointer-events:none; }
 
 .server-status-card {
   max-width: 1000px;
@@ -109,7 +238,13 @@ const {
   padding: 32px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(10px);
+  pointer-events:auto;
+  overflow: hidden;
 }
+.server-status-card { position:relative; }
+.server-status-card::before { content:""; position:absolute; top:0; left:6px; right:6px; height:6px; border-top-left-radius:6px; border-top-right-radius:6px; background:linear-gradient(90deg,#fbbf24,#f59e0b,#d97706); }
+.fade-in-card { animation: mainCardIn .8s ease-out; }
+@keyframes mainCardIn { from { opacity:0; transform:translateY(24px) scale(.98); } 60% { opacity:.85; transform:translateY(-4px) scale(1.01);} to { opacity:1; transform:translateY(0) scale(1);} }
 
 .server-info {
   animation: fadeIn 0.6s ease-out;
@@ -133,7 +268,102 @@ const {
   border-top: 1px solid #f0f0f0;
 }
 
-/* 卡片悬停效果 */
+.summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 20px;
+  padding: 12px 20px;
+  background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(109,40,217,0.08));
+  border: 1px solid rgba(99,102,241,0.15);
+  border-radius: 14px;
+  position: relative;
+  pointer-events:auto;
+}
+.summary-bar::before { content:""; position:absolute; top:0; left:12px; right:12px; height:1px; background:linear-gradient(90deg, rgba(99,102,241,.35), rgba(139,92,246,.25), rgba(99,102,241,.35)); opacity:.55; pointer-events:none; }
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  position: relative;
+}
+.summary-item .label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: #6366F1;
+  margin-bottom: 4px;
+}
+.utilization {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+.util-bar {
+  position: relative;
+  height: 22px;
+  background: #EEF2FF;
+  border-radius: 999px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(99,102,241,0.15);
+}
+.util-bar.zero { background: repeating-linear-gradient(45deg, #EEF2FF 0 12px, #E2E8F0 12px 24px); }
+.util-inner {
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  transition: width .6s cubic-bezier(.4,0,.2,1), background .3s;
+  background: #6366F1;
+}
+.util-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+.metric-val { display:inline-block; animation:metricIn .25s ease-out; }
+@keyframes metricIn { from { opacity:0; transform:translateY(6px);} to { opacity:1; transform:translateY(0);} }
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1E293B;
+  mix-blend-mode: multiply;
+}
+
+.avg-ping-item { min-width: 200px; }
+.avg-ping-box { position: relative; width: 180px; height: 50px; border-radius: 12px; background: linear-gradient(135deg,#EEF2FF,#F8FAFC); overflow:hidden; box-shadow: inset 0 0 0 1px rgba(99,102,241,0.15); }
+.avg-ping-box :deep(svg) { position:absolute; inset:0; }
+.avg-ping-foreground { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; backdrop-filter: blur(1px); }
+
+/* Skeleton */
+.skeleton-blocks { margin-bottom:32px; pointer-events:none; }
+.summary-skeleton { display:flex; gap:18px; margin-bottom:26px; }
+.summary-skeleton .line { height:42px; border-radius:14px; background:linear-gradient(90deg,#eceff4 0%, #f5f7fa 40%, #eceff4 80%); background-size:200% 100%; animation:shimmer 1.3s linear infinite; flex:0 0 auto; }
+.summary-skeleton .w120 { width:140px; }
+.summary-skeleton .w140 { width:180px; }
+.summary-skeleton .w100 { width:120px; }
+.summary-skeleton .w200 { width:260px; flex:1; }
+.preview-skeleton-grid { display:flex; gap:20px 22px; flex-wrap:wrap; }
+.preview-skel { width:260px; height:86px; background:linear-gradient(135deg,#ffffff,#f1f5f9); border:1px solid #d6dee9; border-radius:18px; padding:14px 16px; display:flex; flex-direction:column; justify-content:space-between; position:relative; overflow:hidden; }
+.preview-skel::after { content:""; position:absolute; inset:0; background:linear-gradient(90deg,rgba(255,255,255,0),rgba(255,255,255,.6),rgba(255,255,255,0)); animation:skel-sweep 1.4s ease-in-out infinite; }
+.skel-line { background:#e2e8f0; border-radius:6px; animation:fadePulse 1.6s ease-in-out infinite; }
+.skel-line.h14 { height:14px; }
+.skel-line.h10 { height:10px; }
+.skel-line.w70 { width:70px; }
+.skel-line.w110 { width:110px; }
+.skel-line.w150 { width:150px; }
+@keyframes shimmer { to { background-position:-200% 0; } }
+@keyframes skel-sweep { 0% { transform:translateX(-100%);} 60% { transform:translateX(100%);} 100% { transform:translateX(100%);} }
+@keyframes fadePulse { 0%,100% { opacity:.55;} 50% { opacity:1; } }
+
+  @media (max-width: 860px) {
+    .detail-panel { padding:32px 26px 46px; border-radius:28px; }
+    .detail-header h3 { font-size:18px; }
+    .close-btn { width:36px; height:36px; }
+    .preview-grid { gap:14px; }
+  }
+
+.no-scroll { overflow:hidden !important; }
+
 :deep(.n-card) {
   transition: all 0.3s ease;
 }
@@ -145,10 +375,7 @@ const {
 
 /* 响应式设计 */
 @media (max-width: 768px) {
-  .server-status-container {
-    padding: 20px 12px;
-    padding-top: 75px!important;
-  }
+  .server-status-container { padding: 90px 12px 40px; min-height:calc(100vh - 70px); align-items:flex-start; }
 
   .server-status-card {
     padding: 20px;
@@ -170,10 +397,7 @@ const {
 }
 
 @media (max-width: 480px) {
-  .server-status-container {
-    padding: 16px 8px;
-    padding-top: 70px!important;
-  }
+  .server-status-container { padding: 80px 8px 32px; }
 
   .server-status-card {
     padding: 16px;
@@ -183,10 +407,7 @@ const {
 
 /* 横屏模式优化 */
 @media (max-width: 768px) and (orientation: landscape) {
-  .server-status-container {
-    padding: 12px 16px;
-    padding-top: 60px!important;
-  }
+  .server-status-container { padding: 70px 16px 32px; }
 
   .server-status-card {
     padding: 16px;
@@ -203,4 +424,59 @@ const {
     --n-gap: 32px 32px !important;
   }
 }
+
+  /* 新预览卡片布局 */
+  .preview-grid { display:flex; flex-wrap:wrap; gap:20px 22px; margin-top:6px; margin-bottom:30px; }
+/* 全局 focus 可见样式（仅当前作用域内主要交互元素） */
+:focus-visible { outline:2px solid rgba(99,102,241,.65); outline-offset:2px; }
+  .preview-grid { pointer-events:auto; }
+
+  /* 详情 Overlay */
+  .detail-overlay { position:fixed; inset:0; background:rgba(15,23,42,.6); backdrop-filter:blur(10px) saturate(130%); display:flex; align-items:center; justify-content:center; padding:32px 18px; z-index:4000; }
+  /* 详情面板：提高对比度与层次感 */
+  .detail-panel { width:100%; max-width:960px; background:linear-gradient(145deg,#ffffff 0%, #f1f5f9 100%); border:1px solid rgba(148,163,184,.35); border-radius:30px; box-shadow:0 28px 60px -18px rgba(0,0,0,.30), 0 16px 40px -20px rgba(0,0,0,.22); padding:32px 36px 40px; position:relative; animation:panelIn .45s cubic-bezier(.4,0,.2,1); max-height:calc(100vh - 96px); display:flex; flex-direction:column; color:#334155; }
+  .detail-content { flex:1; overflow-y:auto; margin-top:8px; padding-right:4px; }
+  .detail-content::-webkit-scrollbar { width:8px; }
+  .detail-content::-webkit-scrollbar-track { background:transparent; }
+  .detail-content::-webkit-scrollbar-thumb { background:rgba(99,102,241,.35); border-radius:4px; }
+  .detail-content::-webkit-scrollbar-thumb:hover { background:rgba(99,102,241,.55); }
+  @keyframes panelIn { from { opacity:0; transform:translateY(28px) scale(.98);} to { opacity:1; transform:translateY(0) scale(1);} }
+  .detail-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:22px; }
+  .detail-header h3 { margin:0; font-size:22px; font-weight:600; letter-spacing:.5px; color:#1e293b; }
+  /* 内部卡片统一边框与背景，增强区块分隔 */
+  .detail-content :deep(.n-card:not(.status-card)) { background:linear-gradient(135deg,#ffffff 0%, #f8fafc 100%) !important; border:1px solid #e2e8f0; box-shadow:0 2px 4px -2px rgba(0,0,0,.04), 0 4px 10px -4px rgba(0,0,0,.06); color:#334155; }
+  /* 恢复状态卡原始背景，不受统一覆盖影响 */
+  /* 状态卡使用自身在线/离线渐变 */
+  /* 状态卡保持自身渐变/边框/阴影样式（不在此处覆写） */
+  .detail-content :deep(.n-card .n-card__header) { border-bottom:1px solid #e5e7eb; }
+  .detail-content :deep(.n-tag) { font-weight:600; }
+  .detail-content :deep(.n-text[depth="3"]) { color:#64748b; }
+  .close-btn {
+    border:1px solid #cbd5e1;
+    background:#F1F5F9;
+    width:40px; height:40px;
+    border-radius:12px;
+    font-size:22px; font-weight:500;
+    cursor:pointer;
+    display:flex; align-items:center; justify-content:center;
+    color:#334155;
+    transition:background .25s, transform .25s, border-color .25s;
+  }
+  .close-btn:hover { background:#E2E8F0; }
+  .close-btn:active { transform:scale(.92); }
+  .close-btn:focus { outline:none; }
+  .close-btn:focus-visible { outline:2px solid rgba(99,102,241,.65); outline-offset:2px; }
+
+  /* 过渡 */
+  .detail-fade-enter-active, .detail-fade-leave-active { transition: opacity .35s ease; }
+  .detail-fade-enter-from, .detail-fade-leave-to { opacity:0; }
+
+  @media (max-width: 860px) {
+  .detail-panel { padding:26px 22px 34px; border-radius:26px; max-height:calc(100vh - 72px); }
+    .detail-header h3 { font-size:18px; }
+    .close-btn { width:36px; height:36px; }
+    .preview-grid { gap:14px; }
+  }
+
+  .no-scroll { overflow:hidden !important; }
 </style>

--- a/src/views/ServerStatusView.vue
+++ b/src/views/ServerStatusView.vue
@@ -6,38 +6,52 @@
     </div>
     <div class="server-status-container">
   <div class="server-status-card fade-in-card">
-      <ServerStatusHeader :loading="loading" @refresh="fetchServers" />
+  <ServerStatusHeader />
       <n-divider />
   <LoadingErrorState :loading="loading" :error="error" :has-data="serverDataList.length > 0" @retry="fetchServers" />
-  <div v-if="!loading && serverDataList.length" class="summary-bar" aria-live="polite">
+  <div v-if="showSummary" class="summary-bar" aria-live="polite" role="group" aria-label="服务器总体概览">
         <div class="summary-item">
           <span class="label">在线服务器</span>
-          <n-tag :type="onlineServers > 0 ? 'success' : 'error'" size="small" round>
-            <span class="metric-val" :key="onlineServers">{{ onlineServers }}</span>/{{ totalServers }}
-          </n-tag>
+          <div class="metric-line" aria-label="在线服务器">
+            <span class="val" :key="onlineServers">{{ onlineServers }}</span>
+            <span class="sep">/</span>
+            <span class="total">{{ totalServers }}</span>
+          </div>
         </div>
         <div class="summary-item">
           <span class="label">玩家总数</span>
-          <n-tag type="info" size="small" round>
-            <span class="metric-val" :key="totalPlayers">{{ totalPlayers }}</span>/{{ totalMaxPlayers }}
-          </n-tag>
-        </div>
-        <div class="summary-item">
-          <span class="label">平均 Ping</span>
-          <n-tag :type="avgPingTagType" size="small" round>
-            <span class="metric-val" :key="avgPingDisplay">{{ avgPingDisplay }}</span>
-          </n-tag>
-        </div>
-        <div class="summary-item utilization" v-if="totalMaxPlayers > 0">
-          <span class="label">整体利用率</span>
-          <div class="util-bar" :class="{ zero: utilizationPercent === 0 }">
-            <div class="util-inner" :style="{ width: utilizationPercent + '%', background: utilizationColor }"></div>
-            <span class="util-text"><span class="metric-val" :key="utilizationPercent.toFixed(0)">{{ utilizationPercent.toFixed(0) }}</span>%</span>
+          <div class="metric-line" aria-label="玩家总数">
+            <span class="val" :key="totalPlayers">{{ totalPlayers }}</span>
+            <span class="sep">/</span>
+            <span class="total">{{ totalMaxPlayers }}</span>
           </div>
         </div>
+        <div class="summary-item">
+          <span class="label">平均 PING</span>
+          <div class="metric-line" aria-label="平均 Ping">
+            <span class="val" :key="avgPingDisplay">{{ avgPingDisplay }}</span>
+          </div>
+        </div>
+        <div class="summary-item utilization" v-if="totalMaxPlayers > 0">
+          <div class="util-head">
+            <span class="label">整体利用率</span>
+            <span class="util-num" :style="{ color: utilizationColor }">{{ utilizationPercent.toFixed(0) }}%</span>
+          </div>
+          <div class="util-bar" :class="{ zero: utilizationPercent === 0 }" role="progressbar" :aria-valuenow="Math.round(utilizationPercent)" aria-valuemin="0" aria-valuemax="100">
+            <div class="util-inner" :style="{ width: utilizationPercent + '%', background: utilizationColor }"></div>
+          </div>
+        </div>
+        <!-- 刷新按钮（靠右） -->
+  <button :class="['summary-refresh-btn', { loading }]" :disabled="loading" @click="handleRefresh" aria-label="立即刷新" title="立即刷新">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="23 4 23 10 17 10" />
+            <polyline points="1 20 1 14 7 14" />
+            <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+          </svg>
+        </button>
       </div>
 
-  <div v-if="!loading && serverDataList.length" class="preview-grid" aria-label="服务器列表">
+  <div v-if="showSummary" class="preview-grid" aria-label="服务器列表">
         <ServerPreviewCard
           v-for="(sd, idx) in serverDataList"
           :key="idx"
@@ -50,7 +64,20 @@
 
       <div v-else-if="loading" class="skeleton-blocks">
         <div class="summary-skeleton" aria-hidden="true">
-          <div class="line w120" /><div class="line w140" /><div class="line w100" /><div class="line w200" />
+          <div class="metric-skel" v-for="m in 3" :key="m">
+            <div class="skel-num" />
+            <div class="skel-label" />
+          </div>
+          <div class="util-skel">
+            <div class="util-head-skel">
+              <div class="skel-label short" />
+              <div class="skel-num sm" />
+            </div>
+            <div class="util-bar-skel">
+              <div class="fill" />
+            </div>
+          </div>
+          <div class="refresh-skel" />
         </div>
         <div class="preview-skeleton-grid" aria-hidden="true">
           <div class="preview-skel" v-for="n in 2" :key="n">
@@ -103,6 +130,11 @@
         </transition>
       </teleport>
 
+      <!-- 底部更新时间与手动刷新 -->
+      <div v-if="showSummary" class="last-updated footer-update" aria-live="polite">
+        <span>上次更新：<strong>{{ lastUpdated || '—' }}</strong></span>
+      </div>
+
     </div>
     </div>
   </div>
@@ -110,10 +142,9 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { NGrid, NGridItem, NDivider } from 'naive-ui'
+import { NGrid, NGridItem, NDivider, useMessage } from 'naive-ui'
 import { ServerStatusCard, ServerInfoCard, PlayerInfoCard, ConnectionCard, PlayerList, ServerStatusHeader, LoadingErrorState } from '@/components/ServerStatus'
 import { useMultiServerStatus } from '@/composables/useMultiServerStatus'
-import { NTag } from 'naive-ui'
 import ServerPreviewCard from '@/components/ServerStatus/ServerPreviewCard.vue'
 
 // 配置需要展示的服务器地址（可扩展）
@@ -126,11 +157,12 @@ const serverConfigs: ServerConfig[] = [
 ]
 const serverAddresses = serverConfigs.map(c => c.address)
 
-const { loading, error, serverDataList, fetchServers } = useMultiServerStatus(serverAddresses)
+const { loading, error, serverDataList, lastUpdated, fetchServers } = useMultiServerStatus(serverAddresses)
+const message = useMessage()
 
 // 折叠视图逻辑已移除（预览卡取代）
 
-// 汇总统计
+// 汇总统计与派生显示
 const totalServers = computed(() => serverDataList.value.length)
 const onlineServers = computed(() => serverDataList.value.filter(s => s.online).length)
 const totalPlayers = computed(() => serverDataList.value.reduce((sum, s) => sum + (s.players || 0), 0))
@@ -138,21 +170,34 @@ const totalMaxPlayers = computed(() => serverDataList.value.reduce((sum, s) => s
 const pingValues = computed(() => serverDataList.value.map(s => s.ping).filter((p): p is number => typeof p === 'number' && p > 0))
 const avgPing = computed(() => pingValues.value.length ? Math.round(pingValues.value.reduce((a, b) => a + b, 0) / pingValues.value.length) : null)
 const avgPingDisplay = computed(() => avgPing.value != null ? `${avgPing.value}ms` : '未知')
-const avgPingTagType = computed(() => {
-  if (avgPing.value == null) return 'default'
-  if (avgPing.value <= 40) return 'success'
-  if (avgPing.value <= 80) return 'info'
-  if (avgPing.value <= 120) return 'warning'
-  return 'error'
-})
+// 颜色标签胶囊已移除，avgPingTagType 不再需要
 const utilizationPercent = computed(() => totalMaxPlayers.value ? (totalPlayers.value / totalMaxPlayers.value) * 100 : 0)
+// 利用率颜色（方案A）：低 → 高 = 绿 (#10B981) → 蓝 (#3B82F6) → 橙 (#F59E0B) → 红 (#DC2626)
+// 阈值区间：0-39 绿（空闲/健康） | 40-74 蓝（中等） | 75-89 橙（偏高） | 90+ 红（高危）
 const utilizationColor = computed(() => {
   const v = utilizationPercent.value
-  if (v >= 90) return '#DC2626'
-  if (v >= 75) return '#F59E0B'
-  if (v >= 40) return '#10B981'
-  return '#3B82F6'
+  if (v >= 90) return '#DC2626' // 红 高危
+  if (v >= 75) return '#F59E0B' // 橙 偏高
+  if (v >= 40) return '#3B82F6' // 蓝 中等
+  return '#10B981'              // 绿 低负载
 })
+const showSummary = computed(() => !loading.value && serverDataList.value.length > 0)
+
+// 刷新封装：带成功/失败提示
+const handleRefresh = async () => {
+  if (loading.value) return
+  const prevError = error.value
+  try {
+    await fetchServers()
+    if (!error.value) {
+      message.success('刷新成功')
+    } else if (error.value && error.value !== prevError) {
+      message.error(`刷新失败: ${error.value}`)
+    }
+  } catch {
+    message.error('刷新过程中出现异常')
+  }
+}
 
 // Demo 详情展开逻辑
 const detailIndex = ref<number | null>(null)
@@ -271,34 +316,34 @@ onUnmounted(() => {
 .summary-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  margin-bottom: 20px;
-  padding: 12px 20px;
-  background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(109,40,217,0.08));
-  border: 1px solid rgba(99,102,241,0.15);
-  border-radius: 14px;
+  align-items: flex-start;
+  gap: 18px;
+  margin-bottom: 24px;
+  padding: 16px 20px 18px;
+  background: linear-gradient(135deg,#ffffff 0%, #f1f5f9 100%);
+  border: 1px solid #d6dee9;
+  border-radius: 18px;
   position: relative;
   pointer-events:auto;
+  color:#1E293B;
 }
-.summary-bar::before { content:""; position:absolute; top:0; left:12px; right:12px; height:1px; background:linear-gradient(90deg, rgba(99,102,241,.35), rgba(139,92,246,.25), rgba(99,102,241,.35)); opacity:.55; pointer-events:none; }
 .summary-item {
   display: flex;
   flex-direction: column;
   min-width: 120px;
   position: relative;
 }
-.summary-item .label {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: .5px;
-  text-transform: uppercase;
-  color: #6366F1;
-  margin-bottom: 4px;
-}
+.summary-item .label { font-size:12px; font-weight:600; letter-spacing:.5px; text-transform:uppercase; color:#1E293B; margin-bottom:6px; }
+.metric-line { display:flex; align-items:baseline; gap:4px; font-variant-numeric:tabular-nums; }
+.metric-line .val { font-size:20px; font-weight:600; color:#1E293B; letter-spacing:.5px; }
+.metric-line .total { font-size:14px; font-weight:500; color:#64748B; }
+.metric-line .sep { font-size:16px; color:#94A3B8; }
 .utilization {
   flex: 1 1 220px;
   min-width: 200px;
 }
+.util-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:6px; }
+.util-num { font-size:14px; font-weight:600; }
 .util-bar {
   position: relative;
   height: 22px;
@@ -315,19 +360,25 @@ onUnmounted(() => {
   transition: width .6s cubic-bezier(.4,0,.2,1), background .3s;
   background: #6366F1;
 }
-.util-text {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-.metric-val { display:inline-block; animation:metricIn .25s ease-out; }
-@keyframes metricIn { from { opacity:0; transform:translateY(6px);} to { opacity:1; transform:translateY(0);} }
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 600;
-  color: #1E293B;
-  mix-blend-mode: multiply;
+/* 移除旧的中间百分比文字，利用率数值移至头部 */
+.summary-refresh-btn {
+  margin-left:auto;
+  align-self:center; /* 垂直居中 */
+  background:#F1F5F9;
+  border:1px solid #CBD5E1;
+  color:#0F766E;
+  width:40px; height:40px;
+  display:flex; align-items:center; justify-content:center;
+  border-radius:12px; cursor:pointer;
+  transition:background .25s, box-shadow .25s, transform .25s;
 }
+.summary-refresh-btn:hover:not(:disabled) { background:#E2E8F0; box-shadow:0 4px 12px rgba(0,0,0,.08); }
+.summary-refresh-btn:active:not(:disabled) { transform:scale(.94); }
+.summary-refresh-btn:disabled { opacity:.55; cursor:not-allowed; }
+.summary-refresh-btn.loading { box-shadow:0 0 0 0 rgba(15,118,110,.45); animation:pulseRing 1.6s ease-out infinite; }
+.summary-refresh-btn.loading svg { animation:spinBtn .9s linear infinite; }
+@keyframes spinBtn { to { transform:rotate(360deg); } }
+@keyframes pulseRing { 0% { box-shadow:0 0 0 0 rgba(15,118,110,.45);} 70% { box-shadow:0 0 0 10px rgba(15,118,110,0);} 100% { box-shadow:0 0 0 0 rgba(15,118,110,0);} }
 
 .avg-ping-item { min-width: 200px; }
 .avg-ping-box { position: relative; width: 180px; height: 50px; border-radius: 12px; background: linear-gradient(135deg,#EEF2FF,#F8FAFC); overflow:hidden; box-shadow: inset 0 0 0 1px rgba(99,102,241,0.15); }
@@ -336,12 +387,21 @@ onUnmounted(() => {
 
 /* Skeleton */
 .skeleton-blocks { margin-bottom:32px; pointer-events:none; }
-.summary-skeleton { display:flex; gap:18px; margin-bottom:26px; }
-.summary-skeleton .line { height:42px; border-radius:14px; background:linear-gradient(90deg,#eceff4 0%, #f5f7fa 40%, #eceff4 80%); background-size:200% 100%; animation:shimmer 1.3s linear infinite; flex:0 0 auto; }
-.summary-skeleton .w120 { width:140px; }
-.summary-skeleton .w140 { width:180px; }
-.summary-skeleton .w100 { width:120px; }
-.summary-skeleton .w200 { width:260px; flex:1; }
+/* 新 summary 骨架：模拟实际布局与卡片风格 */
+.summary-skeleton { display:flex; flex-wrap:wrap; gap:18px; margin-bottom:28px; padding:16px 20px 18px; background:linear-gradient(135deg,#ffffff 0%, #f1f5f9 100%); border:1px solid #d6dee9; border-radius:18px; position:relative; overflow:hidden; }
+.summary-skeleton::after { content:""; position:absolute; inset:0; background:linear-gradient(120deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.55) 45%,rgba(255,255,255,0) 70%); animation:skel-sweep 2.2s ease-in-out infinite; }
+.metric-skel { width:120px; display:flex; flex-direction:column; gap:8px; }
+.skel-num { height:18px; width:78px; border-radius:4px; background:linear-gradient(90deg,#e2e8f0 0%, #f1f5f9 50%, #e2e8f0 100%); background-size:200% 100%; animation:shimmer 1.4s linear infinite; }
+.skel-num.sm { width:36px; height:14px; }
+.skel-label { height:10px; width:64px; border-radius:4px; background:linear-gradient(90deg,#e2e8f0 0%, #f1f5f9 50%, #e2e8f0 100%); background-size:200% 100%; animation:shimmer 1.6s linear infinite; opacity:.8; }
+.skel-label.short { width:54px; }
+.util-skel { flex:1 1 260px; min-width:240px; display:flex; flex-direction:column; gap:10px; }
+.util-head-skel { display:flex; align-items:center; justify-content:space-between; }
+.util-bar-skel { position:relative; height:22px; border-radius:999px; background:#EEF2FF; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(203,213,225,.6); }
+.util-bar-skel .fill { position:absolute; inset:0; width:55%; background:linear-gradient(90deg,#d1fae5,#bfdbfe,#fde68a,#fecaca); background-size:300% 100%; animation:barFlow 2.4s ease-in-out infinite; border-radius:999px; }
+@keyframes barFlow { 0% { background-position:0 0; } 50% { background-position:100% 0; } 100% { background-position:0 0; } }
+.refresh-skel { width:40px; height:40px; border:1px solid #CBD5E1; background:linear-gradient(135deg,#F1F5F9,#E2E8F0); border-radius:12px; position:relative; overflow:hidden; }
+.refresh-skel::before { content:""; position:absolute; inset:0; background:linear-gradient(90deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.8) 50%,rgba(255,255,255,0) 100%); animation:shimmer 1.5s linear infinite; }
 .preview-skeleton-grid { display:flex; gap:20px 22px; flex-wrap:wrap; }
 .preview-skel { width:260px; height:86px; background:linear-gradient(135deg,#ffffff,#f1f5f9); border:1px solid #d6dee9; border-radius:18px; padding:14px 16px; display:flex; flex-direction:column; justify-content:space-between; position:relative; overflow:hidden; }
 .preview-skel::after { content:""; position:absolute; inset:0; background:linear-gradient(90deg,rgba(255,255,255,0),rgba(255,255,255,.6),rgba(255,255,255,0)); animation:skel-sweep 1.4s ease-in-out infinite; }
@@ -363,6 +423,13 @@ onUnmounted(() => {
   }
 
 .no-scroll { overflow:hidden !important; }
+
+/* 底部刷新按钮 */
+.footer-update { display:flex; gap:12px; align-items:center; justify-content:flex-end; font-size:12px; }
+.refresh-btn { background:#EEF2FF; border:1px solid #CBD5E1; padding:4px 12px; border-radius:8px; font-size:12px; cursor:pointer; line-height:1.2; color:#334155; transition:background .2s, box-shadow .2s; }
+.refresh-btn:hover:not(:disabled) { background:#E0E7FF; box-shadow:0 2px 4px rgba(0,0,0,.08); }
+.refresh-btn:active:not(:disabled) { transform:translateY(1px); }
+.refresh-btn:disabled { opacity:.55; cursor:not-allowed; }
 
 :deep(.n-card) {
   transition: all 0.3s ease;

--- a/src/views/ServerStatusView_Old.vue
+++ b/src/views/ServerStatusView_Old.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="server-status-container">
+    <div class="server-status-card">
+      <!-- 页面头部 -->
+      <ServerStatusHeader :loading="loading" @refresh="fetchServerStatus" />
+
+      <n-divider />
+
+      <!-- 加载和错误状态 -->
+      <LoadingErrorState 
+        :loading="loading" 
+        :error="error" 
+        :has-data="!!serverData" 
+        @retry="fetchServerStatus" 
+      />
+
+      <!-- 服务器信息主体 -->
+      <div v-if="!loading || serverData" class="server-info">
+        <n-grid
+          :cols="1"
+          :x-gap="16"
+          :y-gap="12"
+          responsive="screen"
+          :item-responsive="true"
+          :collapsed-rows="2"
+          :cols-xl="2"
+          :cols-lg="2"
+          :cols-md="1"
+          :cols-sm="1"
+          :cols-xs="1"
+        >
+          <!-- 服务器状态卡片 -->
+          <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+            <ServerStatusCard :server-data="serverData" />
+          </n-grid-item>
+
+          <!-- 服务器信息卡片 -->
+          <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
+            <ServerInfoCard :server-data="serverData" />
+          </n-grid-item>
+
+          <!-- 玩家信息卡片 -->
+          <n-grid-item :span="1" :xl-span="1" :lg-span="1" :md-span="1" :sm-span="1" :xs-span="1">
+            <PlayerInfoCard :server-data="serverData" />
+          </n-grid-item>
+
+          <!-- 连接信息卡片 -->
+          <n-grid-item :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+            <ConnectionCard :server-data="serverData" :server-address="serverAddress" />
+          </n-grid-item>
+
+          <!-- 玩家列表 -->
+          <n-grid-item v-if="serverData.online && serverData.playerList.length > 0" :span="1" :xl-span="2" :lg-span="2" :md-span="1" :sm-span="1" :xs-span="1">
+            <PlayerList :player-list="serverData.playerList" />
+          </n-grid-item>
+        </n-grid>
+
+        <!-- 最后更新时间 -->
+        <div class="last-updated">
+          <n-text depth="3">
+            最后更新: {{ lastUpdated }}
+          </n-text>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { NGrid, NGridItem, NDivider, NText } from 'naive-ui'
+import { 
+  ServerStatusCard, 
+  ServerInfoCard, 
+  PlayerInfoCard, 
+  ConnectionCard, 
+  PlayerList, 
+  ServerStatusHeader, 
+  LoadingErrorState 
+} from '@/components/ServerStatus'
+import { useServerStatus } from '@/composables/useServerStatus'
+
+const serverAddress = '43.138.75.104:27015'
+
+const {
+  loading,
+  error,
+  serverData,
+  lastUpdated,
+  fetchServerStatus
+} = useServerStatus()
+</script>
+
+<style scoped>
+.server-status-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 60px 20px;
+  padding-top: 75px!important;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.server-status-card {
+  max-width: 1000px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+}
+
+.server-info {
+  animation: fadeIn 0.6s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.last-updated {
+  text-align: center;
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid #f0f0f0;
+}
+
+/* 卡片悬停效果 */
+:deep(.n-card) {
+  transition: all 0.3s ease;
+}
+
+:deep(.n-card:hover) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+
+/* 响应式设计 */
+@media (max-width: 768px) {
+  .server-status-container {
+    padding: 20px 12px;
+    padding-top: 75px!important;
+  }
+
+  .server-status-card {
+    padding: 20px;
+    border-radius: 16px;
+    margin: 0;
+    max-width: 100%;
+  }
+
+  /* 调整网格间距 */
+  .server-info :deep(.n-grid) {
+    --n-gap: 12px 12px !important;
+  }
+
+  /* 最后更新时间移动端优化 */
+  .last-updated {
+    margin-top: 16px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .server-status-container {
+    padding: 16px 8px;
+    padding-top: 70px!important;
+  }
+
+  .server-status-card {
+    padding: 16px;
+    border-radius: 12px;
+  }
+}
+
+/* 横屏模式优化 */
+@media (max-width: 768px) and (orientation: landscape) {
+  .server-status-container {
+    padding: 12px 16px;
+    padding-top: 60px!important;
+  }
+
+  .server-status-card {
+    padding: 16px;
+  }
+}
+
+/* 超宽屏优化 */
+@media (min-width: 1400px) {
+  .server-status-card {
+    max-width: 1200px;
+  }
+
+  .server-info :deep(.n-grid) {
+    --n-gap: 32px 32px !important;
+  }
+}
+</style>


### PR DESCRIPTION
# Major Improvements

## Add multiple server support
- Dynamic multi-server configuration (IP + display name) with auto-generated preview cards
```JavaScript
// 配置需要展示的服务器地址（可扩展）
// 服务器配置：名称 + 地址；空地址表示占位待配置
interface ServerConfig { name: string; address: string }
// 更新：第一个服务器为正式服，第二个服务器地址未公布
const serverConfigs: ServerConfig[] = [
  { name: '娱乐对抗正式服', address: '110.42.41.225:27015' },
  { name: '活动专用服务器 - 待上线', address: '' } // 空表示未公布
]
```

## Enhance server status website UI

<img width="1914" height="976" alt="image" src="https://github.com/user-attachments/assets/d04c54cd-f760-4630-98d5-aa110faa1920" />

<img width="1914" height="976" alt="image" src="https://github.com/user-attachments/assets/dd86383b-7e78-4071-9d4e-29e1b722eceb" />

<img width="1914" height="978" alt="image" src="https://github.com/user-attachments/assets/f3deec68-e196-47a1-8c58-6f7c467d3bd3" />

<img width="1916" height="974" alt="image" src="https://github.com/user-attachments/assets/dec2534d-7ba4-4a1b-8594-0188dc12fca3" />

<img width="1915" height="976" alt="image" src="https://github.com/user-attachments/assets/bd991c78-f839-4e45-a887-2bfea9f4261c" />

<img width="1916" height="975" alt="image" src="https://github.com/user-attachments/assets/796f4a72-1efa-4d3c-8bac-fa604013052a" />

# 
